### PR TITLE
Add support configurable for transform options and nullable transforms

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -265,12 +265,12 @@ module.exports = function $initPubSubMQTT(context, config) {
     /*
      * Ensure messages have uuid
      */
-    pubsub.addTransform(require('./transforms/ensure.uuid'));
+    pubsub.addTransform(require('./transforms/ensure.uuid')(config));
 
     /*
      * Ensure messages have timestamp
      */
-    pubsub.addTransform(require('./transforms/ensure.timestamp'));
+    pubsub.addTransform(require('./transforms/ensure.timestamp')(config));
 
     pubsub.addTransform(function(data = {}) {
         return JSON.stringify(data);

--- a/lib/init.js
+++ b/lib/init.js
@@ -253,7 +253,9 @@ module.exports = function $initPubSubMQTT(context, config) {
 
     pubsub.addTransform = function(transform) {
         if (!pubsub._transforms) pubsub._transforms = [];
+        if (!transform) return this;
         pubsub._transforms.push(transform);
+        return this;
     };
 
     pubsub.applyTransforms = function(data = {}) {
@@ -264,6 +266,7 @@ module.exports = function $initPubSubMQTT(context, config) {
      * Ensure messages have uuid
      */
     pubsub.addTransform(require('./transforms/ensure.uuid'));
+
     /*
      * Ensure messages have timestamp
      */

--- a/lib/transforms/ensure.timestamp.js
+++ b/lib/transforms/ensure.timestamp.js
@@ -1,4 +1,41 @@
-module.exports = function(data){
-    if(!data.timestamp) data.timestamp = Date.now();
-    return data;
+'use strict';
+const Keypath = require('gkeypath');
+
+/**
+ * Timestamp transform to ensure event payloads
+ * have a timestamp.
+ * 
+ * Default implementation will add a field named
+ * `timestamp`.
+ * 
+ * You can disable this transformer by setting the
+ * value of the configuration keypath to false.
+ * 
+ * Configuration keypath: `transforms.ensure.timestamp`
+ * 
+ * Configuration options:
+ * - fieldName: timestamp
+ * - getTimestamp: function to generate the timestamp
+ *                 Default to `Date.now()`
+ * 
+ * @param {Object} config 
+ * @param {String} [config.fieldName='timestamp'] 
+ * @param {Function} [config.genTimestamp=Date.now] 
+ */
+module.exports = function $init(config) {
+    const options = Keypath.get(config, 'transforms.ensure.timestamp', {
+        fieldName: 'timestamp',
+        genTimestamp() {
+            return Date.now();
+        }
+    });
+
+    if (options === false) return false;
+
+    const { fieldName, getId } = options;
+
+    return function $transform(data) {
+        if (!data[fieldName]) data[fieldName] = genTimestamp();
+        return data;
+    };
 };

--- a/lib/transforms/ensure.uuid.js
+++ b/lib/transforms/ensure.uuid.js
@@ -1,4 +1,42 @@
-module.exports = function(data){
-    if(!data.uuid) data.uuid = require('uuid').v4();
-    return data;
+'use strict';
+const uuid = require('uuid').v4;
+const Keypath = require('gkeypath');
+
+/**
+ * UUID transform to ensure event payloads
+ * have a unique ID.
+ * 
+ * Default implementation will add a field named
+ * `uuid`.
+ * 
+ * You can disable this transformer by setting the
+ * value of the configuration keypath to false.
+ * 
+ * Configuration keypath: `transforms.ensure.uuid`
+ * 
+ * Configuration options:
+ * - fieldName: uuid
+ * - getId: function to generate the ID
+ *          Default to `uuid.v4()`
+ * 
+ * @param {Object} config 
+ * @param {String} [config.fieldName='uuid'] 
+ * @param {Function} [config.getId=Date.now] 
+ */
+module.exports = function $init(config) {
+    const options = Keypath.get(config, 'transforms.ensure.uuid', {
+        fieldName: 'uuid',
+        getId() {
+            return uuid();
+        }
+    });
+
+    if (options === false) return false;
+
+    const { fieldName, getId } = options;
+
+    return function $transform(data) {
+        if (!data[fieldName]) data[fieldName] = getId();
+        return data;
+    };
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "gextend": "^0.3.0",
+    "gkeypath": "^0.7.2",
     "mqtt": "^2.8.1",
     "mqtt-match": "^1.0.2",
     "uuid": "^3.1.0"


### PR DESCRIPTION
Added support for enabling transformer configuration using the config object. 

Keypath: 

- **transforms.ensure.uuid**
- **transforms.ensure.timestamp**

If we set them to `false` we will skip registering the transformer.

We can configure the following fields:

**ensure.timestamp**:

- fieldName: timestamp
- getTimestamp: function to generate the timestamp. Default to `Date.now()`

**ensure.uuid**:

- fieldName: uuid
- getId:function to generate the ID. Default to `uuid.v4()`

### Examples 

Disable uuid transform:

```js
module.exports = {
	transforms: {
		ensure: {
			uuid: false
		}
	}
};
```

Change options for uuid:

```js
module.exports = {
	transforms: {
		ensure: {
			uuid: {
				fieldName: 'event_id',
				getId(){
					return require('short-id')(10);
				}
			}
		}
	}
};
```

### Changelog

* Close issue #10 
* Close issue #9 
* Transformers can be configured, disabled