### PR TITLE
Add optional keys to configuration to handle request/response flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,66 @@ $ npm i -S core.io-pubsub-mqtt
 
 ### Documentation
 
-
-Request/respond:
+This module provides a request/response flow that you can leverage to replicate HTTP mechanics. The following illustrates a simple example
 
 * client.js:
 
 ```js
-pubsub.request('ci/registry/list').then((event)=>{
-
-}).catch((err)=>{
-    
+pubsub.request('ci/registry/list').then(response => {
+    console.log(repsonse.message) //This is my reponse
+}).catch(error => {
+    //handle error
 });
 ```
 
 * server.js:
 
 ```js
-pubsub.subscribe('ci/registry/list', (event) => {
+pubsub.subscribe('ci/registry/list', event => {
     //...perform logic to generate a result object
-    event.respond({result});
+    let result = { message: 'This is my response' };
+    event.respond({ result });
 });
 ```
 
-Requests have a valid
+If you are using the package as a core.io module and using the dispatch/command flow, you can configure the module to behave use core.io dispatcher handling events with a `respondTo` function so that your commands do not have to worry about specificly handling the `respond` call.
 
+Your application setup:
+
+`./commands/api.image.get.js`
+```js
+class ApiImageGetCommand {
+    execute(event) {
+        return { 
+            success: true, 
+            message: 'This is my command response' 
+        };
+    }
+}
+```
+
+`./config/pubsub.js`:
+
+```js
+module.exports = {
+    responseTopicKey: 'responseTopic',
+    responseCallerKey: 'respondTo',
+    handlers: {
+        'mqtt/api/image/get': function handler(topic message) {
+            const context = this;
+            context.emit('api.image.get', message);
+        }
+    }
+};
+```
+
+
+
+Then from your application dispatching the request:
+
+```js
+let res = await pubsub.request('api.image.get', {filename});
+```
 
 ## License
 ® License MIT 2017 by goliatone

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## core.io PubSub MQTT
-This package is part of the [core.io][core.io] set of libraries, meaning it can be used independently or inside an **core.io** application.
 
-To install
+This package is part of the [core.io][https://github.com/goliatone/application-cor] set of libraries, meaning it can be used independently or inside an **core.io** application.
+
+To install:
 
 ```
 $ npm i -S core.io-pubsub-mqtt

--- a/lib/backoff.js
+++ b/lib/backoff.js
@@ -6,7 +6,7 @@ const backoff = {
     randomizationFactor: 0,
     factor: 3,
     computeDelay: function() {
-        if(!backoff.nextBackoffDelay) backoff.nextBackoffDelay = backoff.initialDelay;
+        if (!backoff.nextBackoffDelay) backoff.nextBackoffDelay = backoff.initialDelay;
         backoff.backoffDelay = Math.min(backoff.nextBackoffDelay, backoff.maxDelay);
         backoff.nextBackoffDelay = backoff.backoffDelay * backoff.factor;
         return backoff.backoffDelay;
@@ -17,7 +17,7 @@ const backoff = {
         backoff.delay = Math.round(backoffDelay * randomFactor);
         return backoff.delay;
     },
-    reset: function(){
+    reset: function() {
         backoff.backoffDelay = 0;
         backoff.delay = 0;
         backoff.nextBackoffDelay = backoff.initialDelay;

--- a/lib/init.js
+++ b/lib/init.js
@@ -17,7 +17,7 @@ const DEFAULTS = {
      * 
      * We set it to `responseTo` by defulat
      * so it's backwards compatible but newer
-     * applications should use `responseTopic` instead.
+     * applications should use `respondTo` instead.
      */
     responseTopicKey: 'respondTo',
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -11,6 +11,25 @@ const DEFAULTS = {
     handlers: {},
     maxConnectionAttempts: 8,
     timeoutResponseAfter: 40 * 1000,
+
+    /**
+     * Used in the request / response flow.
+     * 
+     * We set it to `responseTo` by defulat
+     * so it's backwards compatible but newer
+     * applications should use `responseTopic` instead.
+     */
+    responseTopicKey: 'respondTo',
+
+    /**
+     * Used in the request / response flow.
+     * 
+     * The name of the function added to the
+     * mqtt event payload to handle responses.
+     * We set it to `response` 
+     */
+    responseCallerKey: 'response',
+
     /**
      * The url can be one of the following protocols:
      * mqtt, mqtts, tcp, tls, ws, wss
@@ -124,6 +143,27 @@ module.exports = function $initPubSubMQTT(context, config) {
     _logger.info(config);
 
     /**
+     * Get a registered handler for a given topic.
+     * 
+     * @param {String} topic MQTT topic
+     */
+    pubsub._getHandlerForTopic = function(topic) {
+        return config.handlers[topic];
+    };
+
+    /**
+     * Sets the handler for a given topic.
+     * 
+     * @param {String} topic MQTT topic
+     * @param {Function} handler Topic handler function
+     * @returns {this}
+     */
+    pubsub._setHandlerForTopic = function(topic, handler) {
+        config.handlers[topic] = handler;
+        return this;
+    };
+
+    /**
      * Subscribe to a topic or topics.
      *
      * MQTT topic wildcard characters are
@@ -136,8 +176,7 @@ module.exports = function $initPubSubMQTT(context, config) {
      * @return {this}
      */
     pubsub.subscribe = function(topic, handler) {
-        config.handlers[topic] = handler;
-
+        pubsub._setHandlerForTopic(topic, handler);
         client.subscribe(topic);
 
         return this;
@@ -149,7 +188,7 @@ module.exports = function $initPubSubMQTT(context, config) {
      * @method request
      * @param  {String} topic Topic  String
      * @param  {String|Buffer} data  Payload
-     * @param  {Object} config      Options
+     * @param  {Object} options      Options
      *
      * @return {Promise}
      */
@@ -159,11 +198,12 @@ module.exports = function $initPubSubMQTT(context, config) {
         let responseTopic = `${topic}/res/${rndm}`;
 
         let payload = pubsub._appendToPayload(data, {
-            respondTo: responseTopic
+            [config.responseTopicKey]: responseTopic
         });
 
         return new Promise(function(resolve, reject) {
-            function _handler(topic, event) {
+
+            const _handler = function $handler(topic, event) {
                 console.log('request._handler', topic, event);
 
                 if (_handler._timeoutId) clearTimeout(_handler._timeoutId);
@@ -171,10 +211,10 @@ module.exports = function $initPubSubMQTT(context, config) {
                 /*
                  * Remove response handler
                  */
-                config[responseTopic] = undefined;
+                pubsub._setHandlerForTopic(responseTopic, undefined);
 
                 resolve(event);
-            }
+            };
 
             if (_timeoutResponseAfter) {
                 _handler._timeoutId = setTimeout(_ => {
@@ -185,7 +225,15 @@ module.exports = function $initPubSubMQTT(context, config) {
 
             _logger.info('pubsub.request', payload);
 
+            /**
+             * We expect to get our response over this 
+             * topic.
+             */
             pubsub.subscribe(responseTopic, _handler);
+
+            /**
+             * Publish message.
+             */
             pubsub.publish(topic, payload, options);
         });
     };
@@ -217,10 +265,10 @@ module.exports = function $initPubSubMQTT(context, config) {
      * @method publish
      * @param  {String} topic Topic  String
      * @param  {String|Buffer} data  Payload
-     * @param  {Object} config      Options
-     * @param  {Number} [config.qos=0] QoS level
-     * @param  {Boolean} [config.retain=false] QoS level
-     * @param  {Boolean} [config.dup=false] QoS level
+     * @param  {Object} options      Options
+     * @param  {Number} [options.qos=0] QoS level
+     * @param  {Boolean} [options.retain=false] QoS level
+     * @param  {Boolean} [options.dup=false] QoS level
      * @return {this}
      */
     pubsub.publish = function(topic, data = '', options = undefined) {
@@ -253,6 +301,7 @@ module.exports = function $initPubSubMQTT(context, config) {
     /**
      * Fast publish main difference with a regular
      * publish is that no transformations are applied.
+     * 
      * @param  {String} topic Topic string
      * @param  {String|Buffer} data  Payload
      *
@@ -269,7 +318,9 @@ module.exports = function $initPubSubMQTT(context, config) {
 
         client.publish.apply(client, args);
 
-        _logger.info('|-> pubsub: publish', topic, data);
+        if (config.verbose) {
+            _logger.info('|-> pubsub: publish', topic, data);
+        }
 
         return this;
     };
@@ -300,6 +351,7 @@ module.exports = function $initPubSubMQTT(context, config) {
     });
 
     client.on('connect', () => {
+
         pubsub.online = true;
         pubsub.connectionAttempt = 0;
         backoff.reset();
@@ -322,7 +374,7 @@ module.exports = function $initPubSubMQTT(context, config) {
 
         let topics = Object.keys(config.handlers);
 
-        topics.map((topic) => {
+        topics.map(topic => {
             _logger.info('pubsub: registering topic "%s"', topic);
         });
 
@@ -350,7 +402,7 @@ module.exports = function $initPubSubMQTT(context, config) {
 
             // _logger.info('match FOUND for: %s %s', key, topic);
 
-            let handler = config.handlers[key];
+            let handler = pubsub._getHandlerForTopic(key);
 
             let payload;
             try {
@@ -360,10 +412,17 @@ module.exports = function $initPubSubMQTT(context, config) {
                 payload = message.toString();
             }
 
-            if (payload.respondTo) {
-                payload.response = function(data) {
-                    pubsub.publish(payload.respondTo, data);
+            /**
+             * If our message was part of a request / response flow
+             * we add a response caller function to our payload so
+             * that we can respond to the given request.
+             */
+            if (payload[config.responseTopicKey]) {
+
+                payload[config.responseCallerKey] = function(data) {
+                    pubsub.publish(payload[config.responseTopicKey], data);
                 };
+
             }
 
             /**
@@ -390,7 +449,7 @@ module.exports = function $initPubSubMQTT(context, config) {
         // pubsub.emit('error', err);
     });
 
-    client.on('reconnect', () => {
+    client.on('reconnect', _ => {
         pubsub.online = false;
         ++pubsub.connectionAttempt;
 


### PR DESCRIPTION
Add keys to configuration so we can specify response topic and response handler in req/res flow:

* `responseTopicKey`: default value `respondTo`
* `responseCallerKey`: default value `response`

`responseTopicKey` is used internally by the `pubsub.request` function to pass along the topic over which we expect our response.

`responseCallerKey` is used internally when we receive a message that has a key matching the `resposneTopicKey` value and add a response handler function.

```js
responseTopicKey: 'responseTopic',
responseCallerKey: 'respondTo',
```