### PR TITLE
add: Added new function to add response middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ $ npm i -S core.io-pubsub-mqtt
 
 ### Documentation
 
+#### Request / Response Flow
+
 This module provides a request/response flow that you can leverage to replicate HTTP mechanics. The following illustrates a simple example
 
 * client.js:
@@ -32,7 +34,7 @@ pubsub.subscribe('ci/registry/list', event => {
 });
 ```
 
-If you are using the package as a core.io module and using the dispatch/command flow, you can configure the module to behave use core.io dispatcher handling events with a `respondTo` function so that your commands do not have to worry about specificly handling the `respond` call.
+If you are using the package as a core.io module and using the dispatch/command flow, you can configure the module to behave use core.io dispatcher handling events with a `respondTo` function so that your commands do not have to worry about specifically handling the `respond` call.
 
 Your application setup:
 
@@ -70,6 +72,82 @@ Then from your application dispatching the request:
 ```js
 let res = await pubsub.request('api.image.get', {filename});
 ```
+
+#### Response Middleware
+
+You can add response middleware to build the payload of your response object.
+Note that the middleware will be applied before applying any transformations done in during the payload publish.
+
+
+In your config file:
+
+* config/pubsub.js:
+
+```js
+module.exports = {
+
+    /**
+     * These functions will be called in the
+     * order they are added
+     */ 
+    responseMiddleware: [
+        function(response, data, error) {
+            
+            if(data && !error) {
+                response.data = data;
+                response.success = true;
+            }
+            
+            if(error && !data) {
+                response.error = error;
+                response.success = false;
+            }
+
+            return response;
+        },
+        
+    ]
+};
+```
+
+#### Publish Payload Transformers
+
+You can modify the payload before being published ove MQTT. By default we have two transformers, one to add a [timestamp](https://github.com/goliatone/core.io-pubsub-mqtt/blob/master/lib/transforms/ensure.timestamp.js) and one to add a [uuid](https://github.com/goliatone/core.io-pubsub-mqtt/blob/master/lib/transforms/ensure.uuid.js) to the emitted payload.
+
+
+##### Ensure UUID
+
+UUID transform to ensure event payloads have a unique ID.
+
+Default implementation will add a field named `uuid`.
+
+Configuration keypath: `pubsub.transforms.ensure.uuid`.
+
+You can disable this transformer by setting the value of the configuration keypath to `false`.
+
+Configuration options:
+
+- `fieldName`: String representing the payload field name, defaults to `uuid`.
+- `getId`: function to generate the ID. Default to `uuid.v4()`
+
+
+#### Ensure Timestamp
+
+Timestamp transform to ensure event payloads have a timestamp.
+
+Default implementation will add a field named `timestamp`.
+
+Configuration keypath: `transforms.ensure.timestamp`.
+
+You can disable this transformer by setting the value of the configuration keypath to `false`.
+
+
+Configuration options:
+
+- `fieldName`: String representing the payload field name, defaults to `timestamp`.
+- `getTimestamp`: Function to generate the `timestamp`. Default to `Date.now()`
+
+
 
 ## License
 ® License MIT 2017 by goliatone

--- a/lib/init.js
+++ b/lib/init.js
@@ -255,7 +255,10 @@ module.exports = function $initPubSubMQTT(context, config) {
                 }, _timeoutResponseAfter);
             }
 
-            _logger.info('pubsub.request', payload);
+            if (config.verbose) {
+                _logger.info('|-> pubsub.request', payload);
+            }
+
 
             /**
              * We expect to get our response over this 
@@ -305,12 +308,13 @@ module.exports = function $initPubSubMQTT(context, config) {
      */
     pubsub.publish = function(topic, data = '', options = undefined) {
         let args = [topic];
-
         data = pubsub.applyTransforms(data);
+
 
         args.push(data);
 
         if (options) {
+            //TODO: pick only valid arguments
             args.push(options);
         }
 
@@ -359,7 +363,7 @@ module.exports = function $initPubSubMQTT(context, config) {
 
     pubsub.addTransform = function(transform) {
         if (!pubsub._transforms) pubsub._transforms = [];
-        if (!transform !== 'function') return this;
+        if (typeof transform !== 'function') return this;
         pubsub._transforms.push(transform);
         return this;
     };

--- a/lib/init.js
+++ b/lib/init.js
@@ -20,6 +20,11 @@ const DEFAULTS = {
     timeoutResponseAfter: 40 * 1000,
 
     /**
+     * array of middleware functions:
+     * Signature is (result:Object, data:Object?, error:Error?)
+     */
+    responseMiddleware: [],
+    /**
      * format
      * timeoutResponseAfter
      */
@@ -354,13 +359,33 @@ module.exports = function $initPubSubMQTT(context, config) {
 
     pubsub.addTransform = function(transform) {
         if (!pubsub._transforms) pubsub._transforms = [];
-        if (!transform) return this;
+        if (!transform !== 'function') return this;
         pubsub._transforms.push(transform);
         return this;
     };
 
     pubsub.applyTransforms = function(data = {}) {
         return pubsub._transforms.reduce((_data, tx) => tx(_data, this), data);
+    };
+
+    pubsub.addResponseMiddleware = function(middleware) {
+        if (!pubsub.responseMiddleware) pubsub.responseMiddleware = [];
+        if (typeof middleware !== 'function') return this;
+        pubsub.responseMiddleware.push(middleware);
+        return this;
+    };
+
+    pubsub.applyResponseMiddleware = function(data, error) {
+
+        let response = data;
+
+        if (Array.isArray(pubsub.responseMiddleware) && pubsub.responseMiddleware.length > 0) {
+            response = pubsub.responseMiddleware.reduce((response, middleware) => {
+                return response = middleware(response, data, error);
+            }, {});
+        }
+
+        return response;
     };
     ///////////////////////////////////
     /*
@@ -446,8 +471,9 @@ module.exports = function $initPubSubMQTT(context, config) {
              */
             if (payload[config.responseOptions.topicKey]) {
 
-                payload[config.responseOptions.callerKey] = function(data) {
-                    pubsub.publish(payload[config.responseOptions.topicKey], data);
+                payload[config.responseOptions.callerKey] = function(data, error) {
+                    let message = pubsub.applyResponseMiddleware(data, error);
+                    pubsub.publish(payload[config.responseOptions.topicKey], message);
                 };
 
             }


### PR DESCRIPTION
Extend the library to add support for `responseTo` middleware. We can now add middleware functions that will run before we publish a response.