### PR TITLE
Add registry handler and custom on connect payload 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This module provides a request/response flow that you can leverage to replicate 
 
 ```js
 pubsub.request('ci/registry/list').then(response => {
-    console.log(repsonse.message) //This is my reponse
+    console.log(response.message) //This is my response
 }).catch(error => {
     //handle error
 });
@@ -79,9 +79,9 @@ You can add response middleware to build the payload of your response object.
 Note that the middleware will be applied before applying any transformations done in during the payload publish.
 
 
-In your config file:
+In your configuration file:
 
-* config/pubsub.js:
+* `config/pubsub.js`:
 
 ```js
 module.exports = {
@@ -112,7 +112,7 @@ module.exports = {
 
 #### Publish Payload Transformers
 
-You can modify the payload before being published ove MQTT. By default we have two transformers, one to add a [timestamp](https://github.com/goliatone/core.io-pubsub-mqtt/blob/master/lib/transforms/ensure.timestamp.js) and one to add a [uuid](https://github.com/goliatone/core.io-pubsub-mqtt/blob/master/lib/transforms/ensure.uuid.js) to the emitted payload.
+You can modify the payload before being published over MQTT. By default we have two transformers, one to add a [timestamp](https://github.com/goliatone/core.io-pubsub-mqtt/blob/master/lib/transforms/ensure.timestamp.js) and one to add a [uuid](https://github.com/goliatone/core.io-pubsub-mqtt/blob/master/lib/transforms/ensure.uuid.js) to the emitted payload.
 
 
 ##### Ensure UUID

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Your application setup:
 ```js
 class ApiImageGetCommand {
     execute(event) {
-        return { 
-            success: true, 
-            message: 'This is my command response' 
+        return {
+            success: true,
+            message: 'This is my command response'
         };
     }
 }
@@ -89,15 +89,15 @@ module.exports = {
     /**
      * These functions will be called in the
      * order they are added
-     */ 
+     */
     responseMiddleware: [
         function(response, data, error) {
-            
+
             if(data && !error) {
                 response.data = data;
                 response.success = true;
             }
-            
+
             if(error && !data) {
                 response.error = error;
                 response.success = false;
@@ -105,7 +105,7 @@ module.exports = {
 
             return response;
         },
-        
+
     ]
 };
 ```
@@ -151,3 +151,6 @@ Configuration options:
 
 ## License
 ® License MIT 2017 by goliatone
+
+TODO:
+- [ ] Implement a pin/pong flow so that we can easily build on top of it

--- a/lib/init.js
+++ b/lib/init.js
@@ -37,16 +37,16 @@ const DEFAULTS = {
     responseOptions: {
         /**
          * Used in the request / response flow.
-         * 
+         *
          * The name of the function added to the
          * mqtt event payload to handle responses.
-         * We set it to `response` 
+         * We set it to `response`
          */
         callerKey: 'response',
         /**
          * Used in the request / response flow.
-         * 
-         * We set it to `responseTo` by defulat
+         *
+         * We set it to `responseTo` by default
          * so it's backwards compatible but newer
          * applications should use `respondTo` instead.
          */
@@ -102,17 +102,19 @@ const DEFAULTS = {
         return client;
     },
 
-    registerClient: require('./registry'),
+    registerClient: require('./registry').registerClient,
+    registryPingInterval: false,
+    // registryPingInterval: 5 * 60 * 1000,
 };
 
 const _clients = {};
 
 /**
  * Initialize a new MQTT client.
- * 
+ *
  * If you want to connect over tls you need to pass the
  * following options in the `config.transport` object:
- * 
+ *
  * ```js
  * {
  *   key: fs.readFileSync('./tls-key.pem'),
@@ -121,8 +123,8 @@ const _clients = {};
  *   protocol: 'mqtts'
  * }
  * ```
- * 
- * If you are using a self-signed certificate you need to 
+ *
+ * If you are using a self-signed certificate you need to
  * add:
  * ```js
  * {
@@ -131,13 +133,13 @@ const _clients = {};
  * ```
  *
  * @param {Application} context Application core context
- * @param {Object} config Configuratino object
+ * @param {Object} config Configuration object
  * @param {String} [config.clientId] Client id
  * @param {Function} [config.clientId] Client ID, should return a string
  * @param {String} [config.url=mqtt://test.mosquitto.org] MQTT broker URL
  * @param {Number} [config.timeoutResponseAfter=40000] Response timeout
  * @param {Boolean} [config.connectionNeeded=true] If true will throw an error if we fail to connect
- * @param {Number} [config.maxConnectionAttempts=8] Max number of reconnection attemps
+ * @param {Number} [config.maxConnectionAttempts=8] Max number of reconnection attempts
  * @param {String} [config.onconnect.topic=service/up] Topic to send on connection
  * @param {Object} [config.transport] Object passed to MQTT client on connect.
  * @param {Object} [config.transport.will.topic=service/down] Topic to send as LWT
@@ -171,11 +173,12 @@ module.exports = function $initPubSubMQTT(context, config) {
     _logger.info('PubSub MQTT module booting...');
 
     /**
-     * 
+     *
      */
     if (typeof config.registerClient === 'function') {
         try {
-            config.registerClient(client, config);
+            _logger.warn('calling register client function...');
+            config.registerClient(pubsub, config);
         } catch (error) {
             _logger.error('Error registering client...');
             _logger.error(error);
@@ -184,7 +187,7 @@ module.exports = function $initPubSubMQTT(context, config) {
 
     /**
      * Get a registered handler for a given topic.
-     * 
+     *
      * @param {String} topic MQTT topic
      */
     pubsub._getHandlerForTopic = function(topic) {
@@ -193,7 +196,7 @@ module.exports = function $initPubSubMQTT(context, config) {
 
     /**
      * Sets the handler for a given topic.
-     * 
+     *
      * @param {String} topic MQTT topic
      * @param {Function} handler Topic handler function
      * @returns {this}
@@ -241,9 +244,8 @@ module.exports = function $initPubSubMQTT(context, config) {
             options
         );
 
-        let rndm = makeGuid();
         let _timeoutResponseAfter = options.timeoutResponseAfter;
-        let responseTopic = `${topic}/res/${rndm}`;
+        let responseTopic = `${topic}/res/${makeGuid()}`;
 
         let payload = pubsub._appendToPayload(data, {
             [options.topicKey]: responseTopic
@@ -280,7 +282,7 @@ module.exports = function $initPubSubMQTT(context, config) {
 
 
             /**
-             * We expect to get our response over this 
+             * We expect to get our response over this
              * topic.
              */
             pubsub.subscribe(responseTopic, _handler);
@@ -294,15 +296,17 @@ module.exports = function $initPubSubMQTT(context, config) {
 
     /**
      * Extend the current payload with extra data.
-     * @param  {Object} payload Origial payload
+     * @param  {Object} payload Original payload
      * @param  {Object} data    Data to be added to payload
-     *
-     * @return {Object}
+     * @param {Boolean} [serialize=false] If true return string
+     * @return {Object|String}
      */
-    pubsub._appendToPayload = function(payload = {}, data = {}) {
+    pubsub._appendToPayload = function(payload = {}, data = {}, serialize = false) {
         if (payload === '') payload = {};
         if (typeof payload === 'string') payload = JSON.parse(payload);
+        if (typeof data === 'string') data = JSON.parse(data);
         payload = extend({}, data, payload);
+        if (serialize) return JSON.stringify(payload);
         return payload;
     };
 
@@ -328,7 +332,6 @@ module.exports = function $initPubSubMQTT(context, config) {
     pubsub.publish = function(topic, data = '', options = undefined) {
         let args = [topic];
         data = pubsub.applyTransforms(data);
-
 
         args.push(data);
 
@@ -356,7 +359,7 @@ module.exports = function $initPubSubMQTT(context, config) {
     /**
      * Fast publish main difference with a regular
      * publish is that no transformations are applied.
-     * 
+     *
      * @param  {String} topic Topic string
      * @param  {String|Buffer} data  Payload
      *
@@ -439,10 +442,13 @@ module.exports = function $initPubSubMQTT(context, config) {
          * has been connected.
          */
         if (config.onconnect && config.onconnect.topic) {
-            client.publish(config.onconnect.topic, JSON.stringify({
+
+            const connectPayload = pubsub._appendToPayload(config.onconnect.payload, {
                 action: 'up',
                 client: config.clientId,
-            }), function(err) {
+            }, true);
+
+            client.publish(config.onconnect.topic, connectPayload, function(err) {
                 if (err) _logger.error('publish error:', err);
             });
         }
@@ -492,7 +498,7 @@ module.exports = function $initPubSubMQTT(context, config) {
              * we add a response caller function to our payload so
              * that we can respond to the given request.
              * This will be handled by core.io's `respondTo` command
-             * flow. 
+             * flow.
              * @see https://github.com/goliatone/application-core/blob/master/lib/application.js#L1386
              */
             if (payload[config.responseOptions.topicKey]) {
@@ -501,7 +507,6 @@ module.exports = function $initPubSubMQTT(context, config) {
                     let message = pubsub.applyResponseMiddleware(data, error);
                     pubsub.publish(payload[config.responseOptions.topicKey], message);
                 };
-
             }
 
             /**

--- a/lib/init.js
+++ b/lib/init.js
@@ -4,6 +4,7 @@ const extend = require('gextend');
 const match = require('mqtt-match');
 const EventEmitter = require('events');
 const backoff = require('./backoff');
+const pkg = require('../package.json');
 
 let defaultResponseOptions = {
     callerKey: 'response',
@@ -18,6 +19,11 @@ const DEFAULTS = {
     handlers: {},
     maxConnectionAttempts: 8,
     timeoutResponseAfter: 40 * 1000,
+
+    metadata: {
+        version: pkg.version,
+        mqtt: pkg.dependencies.mqtt,
+    },
 
     /**
      * array of middleware functions:
@@ -94,7 +100,9 @@ const DEFAULTS = {
         _clients[url] = client;
 
         return client;
-    }
+    },
+
+    registerClient: require('./registry'),
 };
 
 const _clients = {};
@@ -161,6 +169,18 @@ module.exports = function $initPubSubMQTT(context, config) {
     pubsub._notifiedInitialConnection = false;
 
     _logger.info('PubSub MQTT module booting...');
+
+    /**
+     * 
+     */
+    if (typeof config.registerClient === 'function') {
+        try {
+            config.registerClient(client, config);
+        } catch (error) {
+            _logger.error('Error registering client...');
+            _logger.error(error);
+        }
+    }
 
     /**
      * Get a registered handler for a given topic.
@@ -471,6 +491,9 @@ module.exports = function $initPubSubMQTT(context, config) {
              * If our message was part of a request / response flow
              * we add a response caller function to our payload so
              * that we can respond to the given request.
+             * This will be handled by core.io's `respondTo` command
+             * flow. 
+             * @see https://github.com/goliatone/application-core/blob/master/lib/application.js#L1386
              */
             if (payload[config.responseOptions.topicKey]) {
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,28 +1,61 @@
 /**
  * This provides a default registration flow for
  * pubsub instances.
- * 
+ *
  * Registry tries to coordinate client registration
  * so we can track different application client's
  * states.
- * 
+ *
+ * @param {Client} pubsub PubSub client
+ * @param {Object} config Configuration object
+ */
+module.exports.registerClient = function $registerClient(pubsub, config = {}) {
+
+    const now = Date.now();
+
+    const bipTopic = 'core$/pubsub/instance/beat';
+    const ackTopic = 'core$/pubsub/instance/join';
+
+    let registrationPayload = {
+        client: config.clientId,
+        metadata: config.metadata,
+        boot: now,
+    };
+
+    let initialPayload = JSON.stringify(registrationPayload);
+
+    /**
+     * We should notify that our client is up to
+     * the main system channel
+     */
+    pubsub.client.on('connect', _ => {
+        pubsub.client.publish(ackTopic, initialPayload);
+    });
+
+    let intervalId;
+
+    const ping = _ => {
+        try {
+            registrationPayload.now = Date.now();
+            let pingPayload = JSON.stringify(registrationPayload);
+            pubsub.client.publish(bipTopic, pingPayload);
+        } catch (error) {
+
+        }
+    };
+
+    if (config.registryPingInterval) {
+        intervalId = setInterval(ping, config.registryPingInterval);
+    }
+};
+
+/**
+ * We can create a registry manager to track all different instances
+ * and keep track of who is online and who goes down.
+ *
  * @param {Client} client PubSub client
  * @param {Object} config Configuration object
  */
-module.exports.registerClient = function $registerClient(client, config = {}) {
-
-    const ackTopic = 'core$/pubsub/instance';
-    const registrationPayload = {
-        client: config.clientId,
-        metadata: config.metadata,
-    };
-
-    /**
-     * We should notify that our client is up to 
-     * the main system channel
-     */
-    client.on('connect', _ => {
-        client.publish(ackTopic, registrationPayload);
-    });
+module.exports.createManager = function $createManager(client, config = {}) {
 
 };

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,0 +1,28 @@
+/**
+ * This provides a default registration flow for
+ * pubsub instances.
+ * 
+ * Registry tries to coordinate client registration
+ * so we can track different application client's
+ * states.
+ * 
+ * @param {Client} client PubSub client
+ * @param {Object} config Configuration object
+ */
+module.exports.registerClient = function $registerClient(client, config = {}) {
+
+    const ackTopic = 'core$/pubsub/instance';
+    const registrationPayload = {
+        client: config.clientId,
+        metadata: config.metadata,
+    };
+
+    /**
+     * We should notify that our client is up to 
+     * the main system channel
+     */
+    client.on('connect', _ => {
+        client.publish(ackTopic, registrationPayload);
+    });
+
+};


### PR DESCRIPTION
This PR closes #23 by adding a new configuration option to update the `onconnect` published message.

## onconnect

By default we send:

```js
let payload = {
  action: 'up',
  client: config.clientId
};
```

We can now add a `payload` option and will be merged with the default object:

```js
module.exports = {
	onconnect: {
        topic: 'ww/harvest/location/${app.environment}/${pubsub.clientId}/online',
        payload: '{"action": "online", "client":"${pubsub.clientId}","pipelineId":"${pipeline.instanceId}"}'
    },
};
```
Note that payload can be a JSON string or an Object.

## registerClient

We now run a `registerClient` function on initialization of the module to notify the existence of this instance.